### PR TITLE
Update 1. Hosting Jupyter Server-Lab in Cloud.md

### DIFF
--- a/MLOps/1. Hosting Jupyter Server-Lab in Cloud.md
+++ b/MLOps/1. Hosting Jupyter Server-Lab in Cloud.md
@@ -36,12 +36,14 @@ If your workload is related to AI/ML/DL search for **Deep Learning AMI GPU PyTor
 Or **Any OS of your choice**.
 
 -> Set the instance type to “g4dn-xlarge”. (The "g4dn-xlarge" instance type is a type of Amazon EC2 instance that is optimized for machine learning (ML) workloads and can provide high-performance computing capabilities. It is equipped with NVIDIA T4 GPUs, which can accelerate ML workloads and deliver faster training and inference times.) You may select the instance of your choice based on the workload.
+-> For free tier set the instance type to "t2.micro". (This "t2.micro" instance type is designed for general purpose workloads that do not require high CPU usage.It is one of the lowest priced AWS EC2 instance option.)
 
 ![](assets/4.png)
 -> In the key pair, set the pair type as RSA and file format as .pem (RSA is a popular encryption algorithm used for key pairs, and is supported by Amazon EC2. When you create a key pair, you can select RSA as the key pair type.)
 ![](assets/5.png)
 
-Go to “create security group” and allow the SSH traffic and set the storage details to 1000.
+Go to “create security group” and allow the SSH traffic and set the storage details to 1000. 
+(Note: Free tier customers are eligible upto only 30 GB of EBS General Purpose (SSD) or Magnetic Storage. Set the storage details accordingly if a Free tier customer.)
 #### Security groups: 
 * Security groups are stateful and provide filtering of ingress/egress network traffic to AWS resources.
 * Removing unfettered connectivity to remote console services, such as SSH, reduces a server's exposure to risk. 


### PR DESCRIPTION
For free tier customer -

- Set the instance type to "t2.micro"
- Storage detail to 30 GB